### PR TITLE
More robustness

### DIFF
--- a/sourcemap.go
+++ b/sourcemap.go
@@ -5,10 +5,7 @@
 // in the "Source Map Revision 3 Proposal" available at http://goo.gl/bcVlcK
 package sourcemap
 
-import (
-	"fmt"
-	"sort"
-)
+import "fmt"
 
 // Represents the mapping to a line/column/name in the original file.
 type OriginalMapping struct {
@@ -67,9 +64,18 @@ func (s *SourceMap) GetSourceMapping(linum, column int) (mapping OriginalMapping
 		return s.getPreviousLineMapping(linum)
 	}
 
-	index := sort.Search(len(line), func(i int) bool {
-		return line[i].GeneratedColumn <= column
-	})
+	index := -1
+	for i, entry := range line {
+		if entry.GeneratedColumn <= column {
+			index = i
+			break
+		}
+	}
+
+	if index < 0 {
+		err = fmt.Errorf("unable to map column: %d", column+1)
+		return
+	}
 
 	entry := line[index]
 	s.populateMapping(&mapping, entry)

--- a/sourcemap.go
+++ b/sourcemap.go
@@ -51,7 +51,7 @@ func (s *SourceMap) GetSourceMapping(linum, column int) (mapping OriginalMapping
 	linum--
 	column--
 
-	if linum < 0 || linum > len(s.Mappings) {
+	if linum < 0 || linum >= len(s.Mappings) {
 		err = fmt.Errorf("invalid line number: %v", linum+1)
 		return
 	}


### PR DESCRIPTION
When I used _sourcemap_ in a project, there were mapping files that caused panics.

I fixed an off-by-one error. I also changed the search for a specific column mapping to use a linear search instead of the binary search used by _sort.Search_ -- the mapping files in my project were not sorted in a way expected by the binary search.